### PR TITLE
unordered_associative_task_2_AMarmusevich

### DIFF
--- a/unordered_associative_task_2/student/CMakeLists.txt
+++ b/unordered_associative_task_2/student/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BUILDDIR ${ROOT_DIR}/build)
 set(TEST ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BUILDDIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BUILDDIR}/bin)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(LESSONS_ROOT ${ROOT_DIR}/../../)
 
@@ -26,8 +27,9 @@ set_target_properties(duplicates_search_HOMEWORK PROPERTIES
                         PUBLIC_HEADER "${headers}"
 )
 
-
 target_link_libraries(duplicates_search_HOMEWORK PRIVATE stdc++fs)
+#target_link_libraries(duplicates_search_HOMEWORK stdc++fs)
+#target_link_libraries(${PROJECT_NAME} stdc++fs)
 
 
 target_include_directories(duplicates_search_HOMEWORK

--- a/unordered_associative_task_2/student/src/impl.cpp
+++ b/unordered_associative_task_2/student/src/impl.cpp
@@ -1,9 +1,11 @@
 #include "impl.h"
 #include <experimental/filesystem>
+#include <experimental/unordered_map>
 #include <fstream>
 #include <numeric>
 #include "xxhash.h"
 #include <iostream>
+#include <algorithm>
 
 namespace fs = std::experimental::filesystem;
 
@@ -20,16 +22,35 @@ auto xx_hash = [] (const std::string &file)
 
     const auto length = fs::file_size(file);
     std::vector<char> buffer(length);
-    stream.read(buffer.data(), length);
+    stream.read(buffer.data(), static_cast<std::streamsize>(length)); //avoid varning: implicit conversion changes signedness: 'const unsigned long long' to 'std::streamsize' (aka 'long long')
 
     return xxh::xxhash<64>(buffer);
 };
 
+auto xx_file_size = [] (const std::string &file)
+{
+    return fs::file_size(file);
+};
 
 /** @todo Implement filtering files by different buckets by specified criteria*/
 template<class FilterCriteria>
 filtering_map filter(const std::vector<std::string>& files, FilterCriteria filter)
 {
+    filtering_map ret;
+    for(auto fileName : files)
+    {
+        const size_t key = filter(fileName);
+        if (ret.find(key) != ret.end())
+        {
+            ret[key].push_back(fileName);
+        }
+        else
+        {
+            ret.insert({filter(fileName), std::vector<std::string>{fileName}});
+        }
+    }
+
+    return ret;
 }
 
 /** @note HELPER */
@@ -41,9 +62,73 @@ filtering_map groupDuplicates (const std::vector<std::string>& dataSource, Filte
     return grouped;
 }
 
+// With help of std filesystem, lists all regular files under specified directory recursively/
+std::vector<std::string> listFiles(const std::string& directory)
+{
+    std::vector<std::string> ret;
+    for(auto& p: fs::recursive_directory_iterator(directory))
+    {
+        if(fs::is_regular_file(p))
+        {
+            ret.push_back(p.path().string());
+        }
+    }
+    return ret;
+}
+
+// Implement function that will remove group in if it has only one or zero elements
+void removeUniqueGroups(filtering_map& filteredData)
+{
+    std::experimental::erase_if(filteredData, [](const auto& item) {
+            return item.second.empty() || (item.second.size() == 1);
+        });
+}
+
+// @todo Implement function that will transform map to a vector /
+std::vector<std::string> flattenGrouped (const filtering_map& grouped)
+{
+    std::vector<std::string> ret;
+    for(auto pair : grouped)
+    {
+        std::copy(pair.second.begin(), pair.second.end(), std::back_inserter(ret));
+    }
+
+    return ret;
+}
+
+/*
+ * @todo Implement function that fill find duplicated files under the directory recursively
+ * @param rootPath - directory to check
+ * @return list of duplicated files, grouped by content
+ */
 std::vector<std::vector<std::string> > findDuplicates(const std::string &rootPath)
 {
-    // filter by size
+    const std::vector<std::string>& fileNames = listFiles(rootPath);
+
     // filter by content
-    // flatten
+    const filtering_map& contentGroup = groupDuplicates(fileNames, xx_hash);
+
+    std::vector<std::vector<std::string> > ret;
+    for(auto pair : contentGroup)
+    {
+        std::vector<std::string> group;
+        std::copy(pair.second.begin(), pair.second.end(), std::back_inserter(group));
+        if(!group.empty())
+        {
+            ret.emplace_back(group);
+        }
+    }
+
+
+
+
+    // filter by size
+    //const filtering_map sizeGroup = groupDuplicates(fileNames, xx_file_size);
+    //const std::vector<std::string> flatSizeGroup = flattenGrouped(sizeGroup);
+    //if(!flatSizeGroup.empty())
+    //{
+    //    ret.emplace_back(flatSizeGroup);
+    //}
+
+    return ret;
 }


### PR DESCRIPTION
не очень ясно что делать из-за перезагруженного интерфейса - flattenGrouped  это зачем,
группировка по размеру что одновременно или как

[==========] Running 5 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from ThreeFiles
[ RUN      ] ThreeFiles.OneGroupThreeFiles
[       OK ] ThreeFiles.OneGroupThreeFiles (6 ms)
[ RUN      ] ThreeFiles.ThreeGroupsOneFile
[       OK ] ThreeFiles.ThreeGroupsOneFile (12 ms)
[ RUN      ] ThreeFiles.Reversed
[       OK ] ThreeFiles.Reversed (4 ms)
[----------] 3 tests from ThreeFiles (23 ms total)

[----------] 1 test from TwoFolders
[ RUN      ] TwoFolders.TwoGroups
[       OK ] TwoFolders.TwoGroups (6 ms)
[----------] 1 test from TwoFolders (6 ms total)

[----------] 1 test from NineFiles
[ RUN      ] NineFiles.ThreeGroupsThreeFiles
[       OK ] NineFiles.ThreeGroupsThreeFiles (10 ms)
[----------] 1 test from NineFiles (10 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 3 test suites ran. (40 ms total)
[  PASSED  ] 5 tests.
