### PR TITLE
[Giuseppe Picciuca] iterators_task_3

### DIFF
--- a/iterators_task_3/student/include/impl.h
+++ b/iterators_task_3/student/include/impl.h
@@ -14,9 +14,49 @@ struct pair_iterator : public Iterator
 template<class Iterator, class T>
 struct pair_iterator<Iterator, true, T> : public Iterator
 {
-    /** @todo Iterator traits */
-    /** @todo Iterator operations */
-    /** @todo Constructor from original iterator */
+    public:
+        /** @todo Iterator traits */
+        using value_type = const std::string;
+        using reference = typename Iterator::reference;
+        using pointer = typename Iterator::pointer;
+        using iterator_category = typename Iterator::iterator_category;
+        using difference_type = typename Iterator::difference_type;
+
+        /** @todo Iterator operations */
+        pair_iterator& operator++()
+        {
+            m_iter++;
+            return *this;
+        }
+
+        pair_iterator& operator--()
+        {
+            m_iter--;
+            return *this;
+        }
+
+        value_type& operator*()
+        {
+            return m_iter->first;
+        }
+
+        template<typename _T>
+        void operator=(const _T& val) = delete;
+        
+        operator value_type()
+        {
+            return m_iter->first;
+        }
+
+        /** @todo Constructor from original iterator */
+        pair_iterator() = default;
+
+        pair_iterator(Iterator it)
+            : m_iter(it)
+        {}
+
+    private:
+        Iterator m_iter;
 };
 
 /**
@@ -25,9 +65,59 @@ struct pair_iterator<Iterator, true, T> : public Iterator
 template<class Iterator, class T>
 struct pair_iterator<Iterator, false, T> : public Iterator
 {
-    /** @todo Iterator traits */
-    /** @todo Iterator operations */
-    /** @todo Constructor from original iterator */
+    public:
+        /** @todo Iterator traits */
+        using value_type = size_t;
+        using reference = typename Iterator::reference;
+        using pointer = typename Iterator::pointer;
+        using iterator_category = typename Iterator::iterator_category;
+        using difference_type = typename Iterator::difference_type;
+
+        /** @todo Iterator operations */
+        pair_iterator& operator++()
+        {
+            m_iter++;
+            return *this;
+        }
+
+        pair_iterator& operator++(int)
+        {
+            m_iter++;
+            return *this;
+        }
+
+        pair_iterator& operator--()
+        {
+            m_iter--;
+            return *this;
+        }
+
+        pair_iterator& operator--(int)
+        {
+            m_iter--;
+            return *this;
+        }
+
+        template<typename _T>
+        void operator=(_T& val)
+        {
+            m_iter->second = val;
+        }
+
+        operator value_type()
+        {
+            return m_iter->second;
+        }
+
+        /** @todo Constructor from original iterator */
+        pair_iterator() = default;
+
+        pair_iterator(Iterator it)
+            : m_iter(it)
+        {}
+
+    private:
+        Iterator m_iter;
 };
 
 template<class Iterator>
@@ -40,12 +130,14 @@ using value_iterator = pair_iterator<Iterator, false>;
 template <class MapIterator>
 value_iterator<MapIterator> make_value_iterator (MapIterator iterator)
 {
+    return value_iterator<MapIterator>(iterator);
 };
 
 /** @todo Key iterator generator */
 template <class MapIterator>
 key_iterator<MapIterator> make_key_iterator (MapIterator iterator)
 {
+    return key_iterator<MapIterator>(iterator);
 };
 
 template<class Map>
@@ -62,10 +154,31 @@ template<class Map>
 struct map_keys_view : public base_map_view<Map>
 {
     /** @todo Iterator alias */
-
+    using iterator = key_iterator<typename Map::iterator>;
+    using const_iterator = key_iterator<typename Map::const_iterator>;
     using base_map_view<Map>::base_map_view;
 
     /** @todo begin/end iterators */
+    iterator begin()
+    {
+        return make_key_iterator<iterator>(m_map.begin());
+    }
+
+    iterator end()
+    {
+        return make_key_iterator<iterator>(m_map.end());
+    }
+
+    const_iterator begin() const
+    {
+        return make_key_iterator<const_iterator>(m_map.begin());
+    }
+
+    const_iterator end() const
+    {
+        return make_key_iterator<const_iterator>(m_map.end());
+    }
+
 private:
     using base_map_view<Map>::m_map;
 };
@@ -74,10 +187,30 @@ template<class Map>
 struct map_values_view : public base_map_view<Map>
 {
     /** @todo Iterator alias */
-
+    using iterator = value_iterator<typename Map::iterator>;
     using base_map_view<Map>::base_map_view;
 
     /** @todo begin/end iterators */
+    iterator begin()
+    {
+        return make_value_iterator<iterator>(m_map.begin());
+    }
+
+    iterator end()
+    {
+        return make_value_iterator<iterator>(m_map.end());
+    }
+
+    iterator begin() const
+    {
+        return make_value_iterator<iterator>(m_map.begin());
+    }
+
+    iterator end() const
+    {
+        return make_value_iterator<iterator>(m_map.end());
+    }
+
 private:
     using base_map_view<Map>::m_map;
 };
@@ -86,22 +219,26 @@ private:
 template <class Map>
 map_values_view<Map> make_values_view(Map& map)
 {
+    return map_values_view<Map>(map);
 }
 
 /**  @todo Generator for keys view*/
 template <class Map>
 map_keys_view<Map> make_keys_view(Map& map)
 {
+    return map_keys_view<Map>(map);
 }
 
 /**  @todo Generator for const values view*/
 template <class Map>
 const map_values_view<const Map> make_values_view(const Map& map)
 {
+    return map_values_view<const Map>(map);
 }
 
 /**  @todo Generator for const keys view*/
 template <class Map>
 const map_keys_view<const Map> make_keys_view(const Map& map)
 {
+    return map_keys_view<const Map>(map);
 }

--- a/iterators_task_3/student/tests/unit_tests/headers/maintest.h
+++ b/iterators_task_3/student/tests/unit_tests/headers/maintest.h
@@ -7,7 +7,7 @@ class TypesAndTraits : public ::testing::Test
 {
 
 protected:
-    using key_type = size_t;
+    using key_type = std::string;
     using value_type = size_t;
 
     using map = std::map<key_type, value_type>;


### PR DESCRIPTION
The implementation is unfinished as i've come to a blocking point.

If I uncomment the test Usage.BasicAlgorithm, specifically the part with back_inserter into std::list, then the code compiles. 

With it, it doesn't compile due to this error:
`no match for ‘operator=’ (operand types are ‘std::back_insert_iterator<std::__cxx11::list<long unsigned int> >’ and ‘std::pair<const std::__cxx11::basic_string<char>, long unsigned int>’)`

It complains at this line of code in the STL:
```
template<typename _BidirectionalIterator, typename _OutputIterator>
    _OutputIterator
    reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last,
		 _OutputIterator __result)
    {
      // concept requirements
      __glibcxx_function_requires(_BidirectionalIteratorConcept<
				  _BidirectionalIterator>)
      __glibcxx_function_requires(_OutputIteratorConcept<_OutputIterator,
		typename iterator_traits<_BidirectionalIterator>::value_type>)
      __glibcxx_requires_valid_range(__first, __last);

      while (__first != __last)
	{
	  --__last;
	  *__result = *__last;     // <==== HERE
	  ++__result;
	}
      return __result;
    }
```
Uncommenting this test, it compiles, but crashes in the 
```
operator value_type()
{
        return m_iter->first;
}
```

implementation in each pair_iterator class because it cannot dereference m_iter (I'm guessing it's the end() iterator, not sure).

Lastly, in maintest.h the std::map has keys of type std::string, but 
`using key_type = size_t;`
so the test TypesAndTraits.ValueTypeTraits fails due to mismatched key_types after implementing the type-traits in pair_iterator. 
Changing the above line to std::string fixes it.

Feedback is well appreciated. Thank you!